### PR TITLE
fix: preserve generated config import failures

### DIFF
--- a/packages/eslint-config/src/__tests__/loader.test.ts
+++ b/packages/eslint-config/src/__tests__/loader.test.ts
@@ -50,6 +50,28 @@ describe("getEslintConfig", () => {
       message: expect.stringContaining(path.basename(configPath)),
     })
   })
+
+  it("reports a config as missing when it disappears before import completes", async () => {
+    const opts = { ai: true }
+    writeGeneratedConfig(
+      optionsToFilename(opts),
+      `
+        import { rmSync } from "node:fs"
+
+        const currentModule = new URL(import.meta.url)
+        currentModule.search = ""
+        rmSync(currentModule)
+        throw new Error("removed during import")
+      `,
+    )
+
+    await expect(getEslintConfig(opts)).rejects.toThrow(
+      "eslint-config-setup: No pre-generated config found",
+    )
+    await expect(getEslintConfig(opts)).rejects.not.toThrow(
+      "Pre-generated config failed to load",
+    )
+  })
 })
 
 function writeGeneratedConfig(filename: string, source: string): string {

--- a/packages/eslint-config/src/__tests__/loader.test.ts
+++ b/packages/eslint-config/src/__tests__/loader.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from "vitest"
+/* eslint-disable security/detect-non-literal-fs-filename -- Test fixtures are written to deterministic paths under the package test directory. */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
 
+import { optionsToFilename } from "../hash"
 import { getEslintConfig, getOxlintConfig } from "../loader"
+
+const configsDir = path.join(import.meta.dirname, "..", "configs")
+const generatedTestFiles = new Set<string>()
+
+afterEach(() => {
+  for (const file of generatedTestFiles) {
+    rmSync(file, { force: true })
+  }
+  generatedTestFiles.clear()
+})
 
 describe("getEslintConfig", () => {
   it("throws with a descriptive error for missing config files", async () => {
@@ -17,7 +31,34 @@ describe("getEslintConfig", () => {
   it("includes the options in the error message", async () => {
     await expect(getEslintConfig({ react: true })).rejects.toThrow('"react":true')
   })
+
+  it("preserves the cause when an existing config fails to import", async () => {
+    const opts = { node: true }
+    const configPath = writeGeneratedConfig(
+      optionsToFilename(opts),
+      'throw new Error("plugin exploded during evaluation")',
+    )
+
+    await expect(getEslintConfig(opts)).rejects.toThrow(
+      "Pre-generated config failed to load",
+    )
+    await expect(getEslintConfig(opts)).rejects.toThrow(
+      "plugin exploded during evaluation",
+    )
+    await expect(getEslintConfig(opts)).rejects.toMatchObject({
+      cause: expect.any(Error),
+      message: expect.stringContaining(path.basename(configPath)),
+    })
+  })
 })
+
+function writeGeneratedConfig(filename: string, source: string): string {
+  mkdirSync(configsDir, { recursive: true })
+  const configPath = path.join(configsDir, filename)
+  writeFileSync(configPath, source)
+  generatedTestFiles.add(configPath)
+  return configPath
+}
 
 describe("getOxlintConfig", () => {
   it("throws with a descriptive error for missing config files", () => {

--- a/packages/eslint-config/src/loader.ts
+++ b/packages/eslint-config/src/loader.ts
@@ -19,10 +19,7 @@ export async function getEslintConfig(
   const configPath = path.join(dirname, "configs", filename)
 
   if (!existsSync(configPath)) {
-    throw new Error(
-      `eslint-config-setup: No pre-generated config found for options ${JSON.stringify(opts)}. ` +
-        `Expected file: configs/${filename}. Run "npm run generate" in the package to build configs.`,
-    )
+    throwMissingConfigError(opts, filename)
   }
 
   const configUrl = pathToFileURL(configPath)
@@ -35,6 +32,10 @@ export async function getEslintConfig(
     )) as { default: FlatConfigArray }
     return module.default
   } catch (error) {
+    if (!existsSync(configPath)) {
+      throwMissingConfigError(opts, filename, error)
+    }
+
     throw new Error(
       `eslint-config-setup: Pre-generated config failed to load for options ${JSON.stringify(opts)}. ` +
         `Expected file: configs/${filename}. Original error: ${getErrorMessage(error)}`,
@@ -67,4 +68,20 @@ export function getOxlintConfig(
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function throwMissingConfigError(
+  opts: ConfigOptions,
+  filename: string,
+  cause?: unknown,
+): never {
+  const message =
+    `eslint-config-setup: No pre-generated config found for options ${JSON.stringify(opts)}. ` +
+    `Expected file: configs/${filename}. Run "npm run generate" in the package to build configs.`
+
+  if (cause === undefined) {
+    throw new Error(message)
+  }
+
+  throw new Error(message, { cause })
 }

--- a/packages/eslint-config/src/loader.ts
+++ b/packages/eslint-config/src/loader.ts
@@ -1,6 +1,7 @@
 /* eslint-disable security/detect-non-literal-fs-filename, @typescript-eslint/no-unsafe-type-assertion -- Paths are computed from deterministic hashes in dist/, not from user input. */
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
+import { pathToFileURL } from "node:url"
 
 import type { ConfigOptions, FlatConfigArray, OxlintConfigOptions, OxlintConfigResult } from "./types"
 
@@ -17,16 +18,27 @@ export async function getEslintConfig(
   const dirname = import.meta.dirname
   const configPath = path.join(dirname, "configs", filename)
 
-  try {
-    const module = (await import(
-      /* webpackIgnore: true */
-      `${configPath}?${Date.now()}`
-    )) as { default: FlatConfigArray }
-    return module.default
-  } catch {
+  if (!existsSync(configPath)) {
     throw new Error(
       `eslint-config-setup: No pre-generated config found for options ${JSON.stringify(opts)}. ` +
         `Expected file: configs/${filename}. Run "npm run generate" in the package to build configs.`,
+    )
+  }
+
+  const configUrl = pathToFileURL(configPath)
+  configUrl.search = String(Date.now())
+
+  try {
+    const module = (await import(
+      /* webpackIgnore: true */
+      configUrl.href
+    )) as { default: FlatConfigArray }
+    return module.default
+  } catch (error) {
+    throw new Error(
+      `eslint-config-setup: Pre-generated config failed to load for options ${JSON.stringify(opts)}. ` +
+        `Expected file: configs/${filename}. Original error: ${getErrorMessage(error)}`,
+      { cause: error },
     )
   }
 }
@@ -51,4 +63,8 @@ export function getOxlintConfig(
         `Expected file: oxlint-configs/${filename}. Run "npm run generate" in the package to build configs.`,
     )
   }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }


### PR DESCRIPTION
## Summary

- distinguish missing generated config files from generated configs that exist but fail during import/evaluation
- preserve the original import/evaluation failure as `cause` and include its message in the diagnostic
- import generated config files through `pathToFileURL()` so absolute paths are converted to valid file URLs before cache-busting
- add a regression test for an existing generated config that throws during evaluation

Closes #74

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run check`
- `corepack pnpm --filter eslint-config-setup test -- loader.test.ts`
- `corepack pnpm run build`
- `corepack pnpm run generate`
- direct diagnostic smoke for `{ react: true, ai: true, oxlint: true }` preserving the `eslint-plugin-mdx` cause outside ESLint
