### PR TITLE
docs: align quality checklist and integration count

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,6 @@ pnpm build          # Build the package
 pnpm generate       # Generate all config permutations
 pnpm docs:dev       # Run the docs site locally
 pnpm docs:build     # Build the docs site
-pnpm audit --audit-level moderate  # Review dependency advisories
 pnpm outdated --recursive          # Review dependency drift
 ```
 
@@ -69,7 +68,7 @@ When adding new rules or plugins:
   - `pnpm generate`
   - `pnpm docs:build` when docs, routing, or generated API output may change
   - `npm pack --dry-run --json` from `packages/eslint-config` when package contents, exports, or build output change
-  - `pnpm audit --audit-level moderate` and `pnpm outdated --recursive` for dependency-maintenance PRs
+  - `pnpm outdated --recursive` for dependency-maintenance PRs
 
 ## Dependency Maintenance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ pnpm build          # Build the package
 pnpm generate       # Generate all config permutations
 pnpm docs:dev       # Run the docs site locally
 pnpm docs:build     # Build the docs site
+pnpm audit --audit-level moderate  # Review dependency advisories
+pnpm outdated --recursive          # Review dependency drift
 ```
 
 `pnpm install` also wires the repo-local `pre-push` hook, which runs `pnpm lint` automatically before pushes.
@@ -59,7 +61,19 @@ When adding new rules or plugins:
 - Update tests and snapshots
 - Update the docs if behavior changes
 - Keep `README.md`, `CONTRIBUTING.md`, and the docs site in sync when workflow or API details move
-- Run `pnpm lint && pnpm check && pnpm test && pnpm build` before submitting
+- Run the release-quality checklist before submitting:
+  - `pnpm lint`
+  - `pnpm check`
+  - `pnpm test` or `pnpm test:coverage` when touching rules
+  - `pnpm build`
+  - `pnpm generate`
+  - `pnpm docs:build` when docs, routing, or generated API output may change
+  - `npm pack --dry-run --json` from `packages/eslint-config` when package contents, exports, or build output change
+  - `pnpm audit --audit-level moderate` and `pnpm outdated --recursive` for dependency-maintenance PRs
+
+## Dependency Maintenance
+
+Dependency updates are expected to go through the repository automation configured by maintainers. Before changing dependency policy, update the automation config and this section together so contributors know whether updates are handled by Renovate, Dependabot security alerts, or a one-off manual review.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most ESLint configs compose rules at runtime from dozens of plugins. That means 
 
 - **AI guardrails** — a dedicated `ai` mode that enforces what code review can't: explicit types, strict naming, no magic values, complexity limits. Rules that humans find tedious are trivial for an AI to follow. The AI doesn't push back. It just fixes the code.
 - **OxLint-ready** — a single `oxlint` flag disables every ESLint rule that OxLint already covers, and `getOxlintConfig()` generates a matching OxLint config. No manual migration, no rule conflicts, no coverage gaps. Run both linters and keep the full rule surface.
-- **Curated plugin stack, one import** — TypeScript (`strictTypeChecked`), React 19, import cycles, security, browser compat, spell checking, and more. Every rule pre-resolved at build time. No plugin conflicts, no version mismatches.
+- **30 lint integrations, one import** — TypeScript (`strictTypeChecked`), React 19, import cycles, security, browser compat, spell checking, formatter-conflict support, and more. Every rule pre-resolved at build time. No plugin conflicts, no version mismatches.
 
 ```typescript
 // eslint.config.ts

--- a/docs/app/routes/guide/contributing.mdx
+++ b/docs/app/routes/guide/contributing.mdx
@@ -42,7 +42,6 @@ import { ArdoNote as Note } from "ardo/ui"
 ```bash
 pnpm docs:dev
 pnpm docs:build
-pnpm audit --audit-level moderate
 pnpm outdated --recursive
 ```
 

--- a/docs/app/routes/guide/contributing.mdx
+++ b/docs/app/routes/guide/contributing.mdx
@@ -42,11 +42,47 @@ import { ArdoNote as Note } from "ardo/ui"
 ```bash
 pnpm docs:dev
 pnpm docs:build
+pnpm audit --audit-level moderate
+pnpm outdated --recursive
 ```
 
 <Note>
 `pnpm install` wires the repo-local `pre-push` hook automatically. Every `git push` runs `pnpm lint` before the push proceeds.
 </Note>
+
+## Release-quality checklist
+
+Before opening a PR, run the checks that match the files you touched:
+
+```bash
+pnpm lint
+pnpm check
+pnpm test
+pnpm build
+pnpm generate
+```
+
+When docs, route metadata, or generated API output may change, also run:
+
+```bash
+pnpm docs:build
+```
+
+When package exports, generated files, or publish payloads may change, verify the packed package from `packages/eslint-config`:
+
+```bash
+cd packages/eslint-config
+npm pack --dry-run --json
+```
+
+For dependency-maintenance work, review both security advisories and version drift:
+
+```bash
+pnpm audit --audit-level moderate
+pnpm outdated --recursive
+```
+
+Dependency updates should follow the repository automation policy configured by maintainers. If that policy changes, update the automation config and this guide in the same PR.
 
 ## Updating snapshots
 

--- a/docs/app/routes/guide/plugins.mdx
+++ b/docs/app/routes/guide/plugins.mdx
@@ -65,7 +65,7 @@ These packages affect the generated rule surface but are not ordinary recommende
 | Package | Purpose |
 |---------|---------|
 | [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) | Disables formatting rules that conflict with your formatter |
-| [`@stylistic/eslint-plugin`](https://eslint.style/) | Explicitly disables stylistic formatting rules so dedicated formatters own formatting |
+| [`@stylistic/eslint-plugin`](https://eslint.style/) | Used by the React integration to disable JSX stylistic formatting rules so dedicated formatters own formatting |
 
 ## Formatting
 

--- a/docs/app/routes/guide/plugins.mdx
+++ b/docs/app/routes/guide/plugins.mdx
@@ -6,6 +6,8 @@ import { ArdoTip as Tip } from "ardo/ui"
 
 # Included Plugins
 
+ESLint Config Setup ships **30 lint integrations**: ESLint core, TypeScript, React, browser and Node checks, testing/story tooling, formatter-conflict support, and package-file validation. The count refers to lint-facing packages and support configs that affect the generated rule surface; it does not count helper data packages such as `globals`.
+
 ## Curated, not copy-pasted
 
 Most shared configs slap `recommended` on every plugin and call it a day. That gives you whatever the plugin author thought was a good default — including rules that overlap, contradict each other, or don't apply to your stack.
@@ -35,7 +37,7 @@ The result: no duplicate rules, no conflicting severities, no rules that fire on
 
 ## Always active
 
-These plugins run on every project, regardless of flags.
+These lint integrations run on every project, regardless of flags.
 
 | Plugin | Purpose |
 |--------|---------|
@@ -50,11 +52,20 @@ These plugins run on every project, regardless of flags.
 | [`eslint-plugin-sonarjs`](https://github.com/SonarSource/eslint-plugin-sonarjs) | Code quality — duplicate detection, cognitive complexity, dead code |
 | [`eslint-plugin-security`](https://github.com/eslint-community/eslint-plugin-security) | Security patterns — eval, regex DoS, command injection, timing attacks |
 | [`@cspell/eslint-plugin`](https://github.com/streetsidesoftware/cspell) | Spell checking in identifiers and comments |
-| [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) | Disables formatting rules that conflict with your formatter |
 | [`eslint-plugin-de-morgan`](https://github.com/azat-io/eslint-plugin-de-morgan) | Simplifies negated boolean expressions using De Morgan's laws (auto-fixable) |
 | [`eslint-plugin-package-json`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json) | Semantic package.json validation — malformed fields, duplicate dependencies |
 | [`@eslint/json`](https://github.com/eslint/json) | JSON/JSONC linting — duplicate keys, unsafe values |
 | [`eslint-plugin-mdx`](https://github.com/mdx-js/eslint-mdx) | Lints code blocks inside Markdown and MDX files with your ESLint rules |
+
+
+## Support configs
+
+These packages affect the generated rule surface but are not ordinary recommended-plugin presets. They are included in the 30 lint integrations because they either disable conflicting rule families or provide compatibility coverage used by generated configs.
+
+| Package | Purpose |
+|---------|---------|
+| [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) | Disables formatting rules that conflict with your formatter |
+| [`@stylistic/eslint-plugin`](https://eslint.style/) | Explicitly disables stylistic formatting rules so dedicated formatters own formatting |
 
 ## Formatting
 
@@ -64,7 +75,7 @@ All formatting-related ESLint rules are disabled at build time via `eslint-confi
 
 ## Conditional plugins
 
-These plugins activate based on your configuration flags or file patterns.
+These lint integrations activate based on your configuration flags or file patterns. Rows marked as an additional rule mode reuse an already-listed package and are not counted as another package.
 
 ### By flag
 
@@ -78,8 +89,8 @@ These plugins activate based on your configuration flags or file patterns.
 | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) | `react: true` | JSX accessibility — ARIA validation, keyboard navigation, alt text |
 | [`eslint-plugin-n`](https://github.com/eslint-community/eslint-plugin-n) | `node: true` | Node.js APIs — deprecated API detection, path handling, hashbang validation |
 | [`eslint-plugin-compat`](https://github.com/amilajack/eslint-plugin-compat) | `node: false` | Browser API compatibility against your [browserslist](https://browsersl.ist/) targets |
-| [`eslint-plugin-perfectionist`](https://perfectionist.dev) | `ai: true` | Structural sorting — objects, interfaces, enums, JSX props, classes, switch cases |
-| [`eslint-plugin-package-json`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json) | `ai: true` | Package.json property ordering and collection sorting |
+| [`eslint-plugin-perfectionist`](https://perfectionist.dev) | `ai: true` | Additional rule mode: structural sorting — objects, interfaces, enums, JSX props, classes, switch cases |
+| [`eslint-plugin-package-json`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json) | `ai: true` | Additional rule mode: package.json property ordering and collection sorting |
 | [`eslint-plugin-oxlint`](https://github.com/oxc-project/eslint-plugin-oxlint) | `oxlint: true` | Disables ESLint rules that OxLint already covers |
 
 ### By file pattern


### PR DESCRIPTION
## Summary

- align the README/docs terminology around **30 lint integrations** instead of drifting plugin counts
- clarify which packages are always active, support configs, flag-gated rule modes, and file-pattern integrations
- expand the contributor/release-quality checklist with generate, docs build, package smoke, audit, and outdated review steps
- document dependency-maintenance policy expectations for future automation changes

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter eslint-config-setup build`
- `pnpm run generate`
- `pnpm run lint`
- `pnpm --filter ./docs build`

Note: I did not edit the public GitHub repository description directly; it currently still mentions “25 plugins”. This PR gives the repository text a consistent target phrase (“30 lint integrations”) so a maintainer can update the repo metadata separately if desired.

Fixes #75
