### PR TITLE
docs: add agent-first install guidance

### DIFF
--- a/docs/app/routes/adr/0021-public-loader-api.md
+++ b/docs/app/routes/adr/0021-public-loader-api.md
@@ -1,0 +1,39 @@
+---
+title: "ADR-0021: Public Loader API over Direct Generated Imports"
+---
+
+ADR-0021: Public Loader API over Direct Generated Imports
+
+Status: Accepted
+Date: 2026-02-27 (documented 2026-07-07)
+Extends: ADR-0001, ADR-0002, ADR-0003
+
+## Context
+
+The package ships pre-generated config modules with deterministic hashed filenames. That keeps runtime loading fast and deterministic, but those generated files are an implementation detail:
+
+- filenames depend on the option-to-hash contract
+- generated module shape can evolve with codegen
+- OxLint and ESLint configs have different option sets
+- consumers need meaningful errors when a requested permutation is missing
+
+If consumers imported generated files directly, every internal layout or hash change would become a breaking public API.
+
+## Decision
+
+Expose loader functions as the stable public installation API:
+
+- `getEslintConfig(options)` for ESLint flat config arrays
+- `getOxlintConfig(options)` for generated OxLint config data
+
+Consumers select behavior with documented option flags (`react`, `node`, `ai`, `oxlint`) and never import from `dist/configs/*` or `dist/oxlint-configs/*`.
+
+The loader owns filename calculation, module loading, missing-file errors, and import-failure diagnostics. Generated files remain inspectable output, not a supported import surface.
+
+## Consequences
+
+- Consumers get one stable import path even when generated internals change
+- The hash algorithm stays an internal routing detail instead of user-facing setup knowledge
+- Missing permutations can fail with actionable package-specific messages
+- Documentation, examples, and agent guidance can teach a small API instead of generated file paths
+- The loader must preserve original import failures clearly, because plugin/runtime errors otherwise look like missing generated files

--- a/docs/app/routes/adr/0022-documentation-site-as-product-surface.md
+++ b/docs/app/routes/adr/0022-documentation-site-as-product-surface.md
@@ -1,0 +1,36 @@
+---
+title: "ADR-0022: Documentation Site as Product Surface"
+---
+
+ADR-0022: Documentation Site as Product Surface
+
+Status: Accepted
+Date: 2026-02-27 (documented 2026-07-07)
+
+## Context
+
+`eslint-config-setup` is not only a config package. It contains opinions about rule philosophy, generated permutations, OxLint split-linting, AI-focused rules, React compatibility, and consumer customization.
+
+A README alone becomes hard to scan once the project needs:
+
+- getting-started guidance for humans
+- reference material for options and helper APIs
+- explanations for non-obvious architecture choices
+- ADRs for rule and plugin decisions
+- generated API documentation from source types
+
+The docs also need to be publishable as a stable website for package metadata, GitHub Pages, and future agent-facing references.
+
+## Decision
+
+Maintain a dedicated Ardo documentation workspace and publish it as the canonical long-form documentation surface.
+
+Use the root README for repository/package orientation, but move detailed guides, API reference, and ADRs into the docs site. The docs site is part of the product, not an optional development artifact.
+
+## Consequences
+
+- Complex topics can be split by audience: quick start, configuration, architecture, API, ADRs
+- TypeDoc output keeps public API documentation close to source types
+- ADRs become linkable from guides and PRs instead of living as disconnected repository notes
+- Docs changes need the same validation path as code changes (`lint:docs` and `docs:build`)
+- Sidebar and index maintenance become part of adding new user-facing guidance

--- a/docs/app/routes/adr/0023-agent-first-installation.md
+++ b/docs/app/routes/adr/0023-agent-first-installation.md
@@ -1,0 +1,38 @@
+---
+title: "ADR-0023: Agent-First Installation over Install Script"
+---
+
+ADR-0023: Agent-First Installation over Install Script
+
+Status: Accepted
+Date: 2026-07-07
+Extends: ADR-0021, ADR-0022
+
+## Context
+
+Installing a lint config into an existing repository is rarely a pure package-add operation. Real target repositories may already have:
+
+- a package manager and lockfile that must not be changed
+- monorepo package boundaries
+- existing ESLint, OxLint, Prettier, Biome, or hook configuration
+- custom `lint`, `check`, or CI scripts
+- mixed browser and Node.js runtime folders
+- project-specific TypeScript setup
+
+A traditional install script can add files quickly, but it cannot reliably understand these project-specific constraints. A script that overwrites config would be risky; a script that asks about every branch would still be less flexible than an agent that can inspect the repository and explain a plan.
+
+## Decision
+
+Do not build a broad interactive install script as the primary setup path.
+
+Document an agent-first installation contract instead. The agent should inspect the target repository, choose the right option flags, preserve existing semantics, make the smallest safe edits, and validate the result with the target repo's own commands.
+
+When conflicts exist, the agent should stop and present a migration plan before replacing existing lint configuration.
+
+## Consequences
+
+- Setup can adapt to monorepos, existing lint stacks, and mixed runtime repositories
+- The project avoids encoding fragile repository-detection logic in a one-size-fits-all script
+- Installation guidance must be explicit enough for agents to follow without guessing
+- Human users still get copy-paste examples, but agents get a richer decision workflow
+- A future `doctor` command can validate the target state read-only, but installation guidance does not depend on it

--- a/docs/app/routes/adr/0024-llms-entrypoints.md
+++ b/docs/app/routes/adr/0024-llms-entrypoints.md
@@ -1,0 +1,39 @@
+---
+title: "ADR-0024: llms.txt Entry Points for Agent Guidance"
+---
+
+ADR-0024: llms.txt Entry Points for Agent Guidance
+
+Status: Accepted
+Date: 2026-07-07
+Extends: ADR-0022, ADR-0023
+
+## Context
+
+Agent-first installation needs a compact, discoverable instruction surface. General docs pages are useful, but agents often start from repository root files and need a fast way to find the relevant setup contract.
+
+The repository now has multiple audiences:
+
+- humans reading the docs site
+- agents installing the package into another repository
+- agents reviewing whether an installation is correct
+- maintainers extending the guidance over time
+
+Putting all agent instructions only in a guide page makes them less discoverable from repository-root context. Putting all instructions only in a root text file would duplicate the docs site and become harder to maintain.
+
+## Decision
+
+Add two repository-root agent entry points:
+
+- `llms.txt` as a compact map of package facts, key docs, and preferred agent flow
+- `llms-full.txt` as the complete agent installation reference
+
+Keep the canonical human-readable guide in the docs site at `/guide/agent-install`, and have the root entry points link to that guide and related reference pages.
+
+## Consequences
+
+- Agents can discover installation guidance from the repository root without scanning the full docs site
+- The short file stays suitable for quick context injection
+- The full file can carry the detailed conflict policy, validation expectations, and reporting format
+- Docs and `llms*.txt` must stay aligned when setup behavior changes
+- `llms.txt` is guidance for agents, not a replacement for package APIs or validation tooling

--- a/docs/app/routes/adr/index.mdx
+++ b/docs/app/routes/adr/index.mdx
@@ -4,7 +4,7 @@ title: Architecture Decision Records
 
 # Architecture Decision Records
 
-This project documents significant architectural decisions as ADRs. They are ordered by impact — from core architecture down to individual plugin choices.
+This project documents significant architectural decisions as ADRs. They are ordered by decision number, from the core architecture through plugin choices and installation guidance.
 
 ## Core Architecture
 
@@ -60,3 +60,14 @@ Plugins and tools that were evaluated and intentionally not adopted.
 | [ADR-0018](/adr/0018-no-shopify) | No @shopify/eslint-plugin | Only 2-3 useful rules out of 29 |
 | [ADR-0019](/adr/0019-eslint-react-migration) | Migration to @eslint-react | Replaces unmaintained eslint-plugin-react with modern engine |
 | [ADR-0020](/adr/0020-react-compat-plugin) | React Compat Plugin | Unified `react/` namespace for OxLint-compatible legacy names |
+
+## Consumer Experience
+
+How the package is exposed, documented, and installed by humans or agents.
+
+| # | Decision | Summary |
+|---|----------|---------|
+| [ADR-0021](/adr/0021-public-loader-api) | Public Loader API | Consumers use stable loader functions instead of generated file imports |
+| [ADR-0022](/adr/0022-documentation-site-as-product-surface) | Documentation Site | The docs site is the canonical long-form product documentation surface |
+| [ADR-0023](/adr/0023-agent-first-installation) | Agent-First Installation | Repository-aware agent setup over a broad install script |
+| [ADR-0024](/adr/0024-llms-entrypoints) | llms.txt Entry Points | Root agent files point agents to install guidance and references |

--- a/docs/app/routes/guide/agent-install.mdx
+++ b/docs/app/routes/guide/agent-install.mdx
@@ -1,0 +1,158 @@
+---
+title: Agent Installation
+---
+
+import { ArdoNote as Note } from "ardo/ui"
+
+# Agent Installation
+
+`eslint-config-setup` does not need a large install wizard to be useful in real projects. A coding agent can inspect the target repository, choose the right config shape, make the smallest safe edits, and validate the result.
+
+This guide describes the target behavior for agents installing `eslint-config-setup` into another repository.
+
+<Note>
+This is an agent-facing install contract, not an install script. Agents should adapt it to the target repository instead of applying every example literally.
+</Note>
+
+## Start by inspecting the repo
+
+Before editing, identify:
+
+- package manager and lockfile (`npm`, `pnpm`, or `bun`)
+- single package vs. monorepo layout
+- `package.json` scripts and `packageManager`
+- `tsconfig.json` location
+- existing `eslint.config.*`, `.eslintrc.*`, `oxlint.config.*`, Prettier, Biome, and hook config
+- runtime shape: React/browser, Node.js, mixed runtime, library, app, tests, generated code
+
+If the repository already has substantial lint config, do not replace it silently. Compose with it or present a migration plan first.
+
+## Choose the config flags
+
+Use only the flags that match the target repository:
+
+| Flag | Use when |
+| --- | --- |
+| `react` | The repo contains React, JSX/TSX, component packages, Storybook, or Testing Library. |
+| `node` | The repo contains CLIs, servers, scripts, workers, or Node.js packages. |
+| `ai` | The repo wants stricter conventions for AI-assisted development and generated code review. |
+| `oxlint` | OxLint runs before ESLint in the lint script. |
+
+Mixed frontend/backend repositories often need package-local configs or scoped flat-config blocks. Avoid one global runtime assumption when browser and Node.js code live together.
+
+## Install dependencies
+
+Install the package and peer dependencies with the target repo's package manager:
+
+```bash
+npm install -D eslint-config-setup eslint typescript
+pnpm add -D eslint-config-setup eslint typescript
+bun add -D eslint-config-setup eslint typescript
+```
+
+Do not switch package managers. Do not remove existing formatter, linter, or hook tooling unless the user explicitly asks for a migration.
+
+## Add the ESLint config
+
+Use the public API:
+
+```typescript
+// eslint.config.ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({ react: true })
+```
+
+For JavaScript config files:
+
+```javascript
+// eslint.config.js
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({ react: true })
+```
+
+Never copy generated config files from `eslint-config-setup` internals into the target repository.
+
+## Add OxLint only when it runs first
+
+Use `oxlint: true` only when the lint script runs OxLint before ESLint:
+
+```typescript
+// eslint.config.ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({ react: true, oxlint: true })
+```
+
+```typescript
+// oxlint.config.ts
+import { getOxlintConfig } from "eslint-config-setup"
+
+export default getOxlintConfig({ react: true })
+```
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "lint": "oxlint && eslint ."
+  }
+}
+```
+
+If the target repo already has `oxlint.config.*`, merge deliberately or ask before replacing it.
+
+## Scripts
+
+Prefer the smallest script that fits the repository:
+
+```jsonc
+{
+  "scripts": {
+    "lint": "eslint ."
+  }
+}
+```
+
+If a `lint` script already exists, preserve its semantics. Add `eslint-config-setup` to the existing flow only when the effect is clear.
+
+## Conflict policy
+
+Stop and present a plan before changing:
+
+- existing non-trivial `eslint.config.*`
+- existing legacy `.eslintrc.*`
+- existing `oxlint.config.*`
+- `lint` scripts with project-specific behavior
+- ambiguous `tsconfig.json` ownership
+- monorepos with multiple package roots
+- mixed browser and Node.js code without clear directory boundaries
+
+The plan should say what exists, what should change, which files would be touched, and which validation commands will run.
+
+## Validate the result
+
+After edits, run the target repo's install command if dependencies changed. Then run the smallest meaningful checks available:
+
+```bash
+npm run lint
+pnpm lint
+bun run lint
+```
+
+Also run `check`, typecheck, or package-local lint commands when the target repo already uses them.
+
+Report whether failures are caused by the new setup, pre-existing lint findings, or local environment problems.
+
+## Agent report
+
+Finish with:
+
+- files changed
+- selected flags and why
+- dependencies added or left unchanged
+- validation commands and results
+- unresolved conflicts or follow-up recommendations
+
+Do not report the setup as complete unless validation ran or the reason it could not run is explicit.

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
             items: [
               { text: 'Why This Exists', link: '/guide/why' },
               { text: 'Getting Started', link: '/guide/getting-started' },
+              { text: 'Agent Installation', link: '/guide/agent-install' },
             ],
           },
           {
@@ -91,6 +92,12 @@ export default defineConfig({
               { text: '0016 No Framework Linting', link: '/adr/0016-no-frameworks' },
               { text: '0017 @eslint-react Deferred', link: '/adr/0017-eslint-react-deferred' },
               { text: '0018 No Shopify Plugin', link: '/adr/0018-no-shopify' },
+              { text: '0019 @eslint-react Migration', link: '/adr/0019-eslint-react-migration' },
+              { text: '0020 React Compat Plugin', link: '/adr/0020-react-compat-plugin' },
+              { text: '0021 Public Loader API', link: '/adr/0021-public-loader-api' },
+              { text: '0022 Documentation Site', link: '/adr/0022-documentation-site-as-product-surface' },
+              { text: '0023 Agent-First Installation', link: '/adr/0023-agent-first-installation' },
+              { text: '0024 llms.txt Entry Points', link: '/adr/0024-llms-entrypoints' },
             ],
           },
           { text: 'API Reference', link: '/api-reference' },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,207 @@
+# eslint-config-setup agent reference
+
+`eslint-config-setup` provides pre-generated ESLint flat configs for modern TypeScript projects. It is meant to be installed by humans or agents without copying internal generated config output into the target repository.
+
+Use this file when you are an AI agent installing, reviewing, or repairing `eslint-config-setup` in another repository.
+
+## Core facts
+
+- Package name: `eslint-config-setup`
+- Node.js requirement: >= 22
+- Peer requirements: ESLint >= 10, TypeScript >= 5
+- Main ESLint API: `getEslintConfig(options)`
+- OxLint API: `getOxlintConfig(options)`
+- Rule helper APIs: `disableRule`, `configureRule`, `setRuleSeverity`, `addRule`
+- Supported flags: `react`, `node`, `ai`, `oxlint`
+- Do not import from `dist/configs/*` or copy generated config files into the target repo.
+
+## Installation mindset
+
+Do not behave like a one-size-fits-all install script. Treat the target repository as an existing system.
+
+Before editing:
+
+1. Identify the package manager from lockfiles and `packageManager`.
+2. Identify whether the target is a single package or a monorepo.
+3. Locate `package.json`, `tsconfig.json`, and any existing ESLint, OxLint, Prettier, Biome, or hook config.
+4. Detect whether code is React/browser, Node.js, mixed runtime, library, app, test-heavy, or generated-code-heavy.
+5. Decide whether the setup can be applied directly or needs a conflict plan.
+
+If the target repo already has substantial lint config, do not replace it silently. Either compose `eslint-config-setup` into the existing flat config or present a migration plan.
+
+## Flag selection
+
+Use only the flags that match the target repository.
+
+- `react: true`: React, JSX/TSX, browser UI apps, component packages, Storybook, Testing Library.
+- `node: true`: Node.js packages, CLIs, servers, scripts, workers, build tooling.
+- `ai: true`: repositories that want stricter conventions for AI-assisted development, explicit types, naming, complexity, and maintainability.
+- `oxlint: true`: only when the target repo runs `oxlint` before `eslint`.
+
+Mixed frontend/backend repositories usually need scoped flat-config blocks or package-local configs. Do not assume one global runtime is correct for the whole repo.
+
+## Dependency changes
+
+Install `eslint-config-setup`, ESLint, and TypeScript as development dependencies unless the target repo already has compatible versions.
+
+Common commands:
+
+```sh
+npm install -D eslint-config-setup eslint typescript
+pnpm add -D eslint-config-setup eslint typescript
+bun add -D eslint-config-setup eslint typescript
+```
+
+If enabling OxLint, also install the target repo's preferred OxLint package if it is absent.
+
+Do not change package managers. Do not remove existing formatter or lint dependencies unless the user asked for migration.
+
+## ESLint config target state
+
+Use `eslint.config.ts` when the target tooling supports TypeScript config files:
+
+```ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({
+  react: true,
+})
+```
+
+Use `eslint.config.js` or `eslint.config.mjs` when that better matches the target repo:
+
+```js
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({
+  react: true,
+})
+```
+
+For mixed repos, keep boundaries explicit:
+
+```ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default [
+  ...await getEslintConfig({ react: true }),
+  {
+    files: ["scripts/**/*.{js,ts}", "server/**/*.{js,ts}"],
+    rules: {
+      // Add project-local runtime overrides here.
+    },
+  },
+]
+```
+
+Prefer project-specific scoped blocks over broad global disables.
+
+## OxLint target state
+
+Only use `oxlint: true` in ESLint if OxLint runs first.
+
+```ts
+// eslint.config.ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({
+  react: true,
+  oxlint: true,
+})
+```
+
+```ts
+// oxlint.config.ts
+import { getOxlintConfig } from "eslint-config-setup"
+
+export default getOxlintConfig({
+  react: true,
+})
+```
+
+Example script:
+
+```json
+{
+  "scripts": {
+    "lint": "oxlint && eslint ."
+  }
+}
+```
+
+If the repo already has an OxLint config, merge carefully or present a conflict plan.
+
+## Script target state
+
+Prefer the smallest script that fits the target repo:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint ."
+  }
+}
+```
+
+If existing scripts already run typecheck, tests, or formatting, do not fold them into lint unless that is the repo's convention. Keep `lint`, `lint:fix`, `check`, and `test` semantics aligned with the existing project.
+
+## Conflict handling
+
+Hard conflicts:
+
+- existing non-trivial `eslint.config.*`
+- existing legacy `.eslintrc.*`
+- existing `oxlint.config.*`
+- existing `lint` script with different semantics
+- missing or ambiguous `tsconfig.json`
+- monorepo with multiple package roots
+- mixed browser and Node.js code without clear directory boundaries
+
+When a hard conflict exists:
+
+1. Stop before editing that area.
+2. Explain what exists.
+3. Propose the smallest safe change.
+4. Ask for approval if replacement or semantic migration is needed.
+
+Safe direct edits:
+
+- add missing dependency entries using the existing package manager
+- add a new config file when no lint config exists
+- add `lint` only when no `lint` script exists
+- add documentation comments only where they clarify project-specific boundaries
+
+## Validation
+
+After applying changes, run the target repo's install command if dependencies changed.
+
+Then run the smallest meaningful checks available:
+
+- package manager install in frozen/lockfile mode when appropriate
+- `npm run lint`, `pnpm lint`, or `bun run lint`
+- `npm run check`, `pnpm check`, or `bun run check` if present
+- package-specific lint/check commands in monorepos
+
+If validation fails, distinguish between:
+
+- install/config problems caused by your change
+- pre-existing lint errors revealed by the new config
+- environment or network failures
+
+Report all commands run and the exact remaining blocker.
+
+## Reporting format
+
+When finished, report:
+
+- files changed
+- flags selected and why
+- dependencies added or left unchanged
+- validation commands and results
+- unresolved conflicts or follow-up recommendations
+
+Do not claim the setup is complete unless validation ran or you clearly explain why it could not run.
+
+## Future validator
+
+A separate `doctor` validator is planned as a follow-up. It should verify the target state read-only after agent-guided setup. Installation guidance should not depend on `doctor` existing.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,55 @@
+# eslint-config-setup
+
+> Pre-generated ESLint flat configs for TypeScript, React, Node.js, AI-assisted codebases, and OxLint split-linting.
+
+## Use this package
+
+- Package: `eslint-config-setup`
+- Runtime: Node.js >= 22
+- Peers: ESLint >= 10, TypeScript >= 5
+- Public API: `getEslintConfig()`, `getOxlintConfig()`, rule helper functions
+- Docs: https://sebastian-software.github.io/eslint-config-setup/
+- Source: https://github.com/sebastian-software/eslint-config-setup
+
+## Agent installation
+
+When installing this package into another repository, do not blindly overwrite the existing lint setup. Inspect the target repository first, choose the right flags, propose a plan when conflicts exist, then apply the smallest safe change.
+
+Read:
+
+- `llms-full.txt` for the complete agent install workflow
+- `docs/app/routes/guide/agent-install.mdx` for the guide page source
+- `docs/app/routes/guide/getting-started.mdx` for human installation examples
+- `docs/app/routes/guide/configuration.mdx` for option semantics
+- `docs/app/routes/guide/oxlint.mdx` for split-linting with OxLint
+- `docs/app/routes/guide/react.mdx` for React linting behavior
+- `docs/app/routes/guide/ai-mode.mdx` for strict AI-assisted development rules
+
+Preferred agent flow:
+
+1. Detect package manager and workspace layout.
+2. Inspect existing ESLint, OxLint, Prettier, and package scripts.
+3. Choose only the flags that match the target project: `react`, `node`, `ai`, `oxlint`.
+4. Plan dependency and file changes before editing.
+5. Preserve existing project-specific config unless the user explicitly approves replacing it.
+6. Use the public API from `eslint-config-setup`; never copy generated config files.
+7. Run the target repo's install and lint/check commands.
+8. Report changed files, validation results, and unresolved conflicts.
+
+## Minimal config
+
+```ts
+import { getEslintConfig } from "eslint-config-setup"
+
+export default await getEslintConfig({ react: true })
+```
+
+## OxLint config
+
+Use `oxlint: true` in ESLint only when OxLint runs before ESLint.
+
+```ts
+import { getOxlintConfig } from "eslint-config-setup"
+
+export default getOxlintConfig({ react: true })
+```

--- a/packages/eslint-config/src/__tests__/loader.test.ts
+++ b/packages/eslint-config/src/__tests__/loader.test.ts
@@ -39,16 +39,19 @@ describe("getEslintConfig", () => {
       'throw new Error("plugin exploded during evaluation")',
     )
 
-    await expect(getEslintConfig(opts)).rejects.toThrow(
-      "Pre-generated config failed to load",
-    )
-    await expect(getEslintConfig(opts)).rejects.toThrow(
-      "plugin exploded during evaluation",
-    )
-    await expect(getEslintConfig(opts)).rejects.toMatchObject({
-      cause: expect.any(Error),
-      message: expect.stringContaining(path.basename(configPath)),
-    })
+    let thrown: unknown
+    try {
+      await getEslintConfig(opts)
+    }
+    catch (error) {
+      thrown = error
+    }
+
+    assertError(thrown)
+    expect(thrown.message).toContain("Pre-generated config failed to load")
+    expect(thrown.message).toContain(path.basename(configPath))
+    assertError(thrown.cause)
+    expect(thrown.cause.message).toBe("plugin exploded during evaluation")
   })
 
   it("reports a config as missing when it disappears before import completes", async () => {
@@ -80,6 +83,10 @@ function writeGeneratedConfig(filename: string, source: string): string {
   writeFileSync(configPath, source)
   generatedTestFiles.add(configPath)
   return configPath
+}
+
+function assertError(value: unknown): asserts value is Error {
+  expect(value).toBeInstanceOf(Error)
 }
 
 describe("getOxlintConfig", () => {


### PR DESCRIPTION
## Summary
- add `llms.txt` and `llms-full.txt` as agent-readable entry points for eslint-config-setup
- document an agent-first installation flow that inspects target repos, plans safe changes, and validates results
- add ADR-0021 through ADR-0024 for the public loader API, docs site, agent-first setup, and `llms.txt` entry points
- link the new Agent Installation guide and complete ADR list from the docs sidebar
- fix the loader import-error regression test to avoid the current Vitest valid-expect false positive

## Follow-up
- doctor-style validation is tracked separately in #89

## Validation
- `CI=true pnpm lint:self`
- `CI=true pnpm --filter eslint-config-setup test -- loader.test.ts`
- `CI=true pnpm lint:docs`
- `CI=true pnpm docs:build`