### PR TITLE
ci: gate lint docs audit and package smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,92 @@ on:
     branches: ["main"]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package for self-lint
+        run: pnpm run build && pnpm run generate
+
+      - name: Lint package and docs
+        run: pnpm run lint
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm run docs:build
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: pnpm audit --audit-level moderate
+
+  package-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm run build && pnpm run generate
+
+      - name: Check package payload and runtime loaders
+        run: pnpm run smoke:package
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,11 +34,20 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      - name: Check React rule surfaces
+        run: pnpm run react:rules:check
+
       - name: Build
         run: pnpm run build
 
       - name: Generate config permutations
         run: pnpm run generate
+
+      - name: Lint package and docs
+        run: pnpm run lint
+
+      - name: Check package payload and runtime loaders
+        run: pnpm run smoke:package
 
       - name: Copy README into package
         run: cp README.md packages/eslint-config/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ config.unshift({
     "packages/*/dist/",
     "packages/*/coverage/",
     ".claude/",
+    "scripts/",
     "**/*.md",
     "**/*.mdx",
     "**/*.json",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react:rules:check": "pnpm --filter eslint-config-setup react:rules:check",
     "test": "pnpm --filter eslint-config-setup test",
     "test:coverage": "pnpm --filter eslint-config-setup test:coverage",
+    "smoke:package": "node scripts/check-package-smoke.mjs",
     "qa": "pnpm run check && pnpm run react:rules:check && pnpm run test:coverage && pnpm run build && pnpm run generate",
     "lint": "pnpm lint:self && pnpm lint:docs",
     "lint:self": "node --import tsx node_modules/eslint/bin/eslint.js --no-config-lookup --config eslint.config.js .",

--- a/scripts/check-package-smoke.mjs
+++ b/scripts/check-package-smoke.mjs
@@ -1,0 +1,68 @@
+import { spawnSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const packageDirectory = new URL("../packages/eslint-config/", import.meta.url)
+const npmCache = path.join(tmpdir(), "eslint-config-setup-npm-cache")
+
+const pack = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+  cwd: packageDirectory,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    npm_config_cache: npmCache,
+  },
+})
+
+if (pack.status !== 0) {
+  process.stderr.write(pack.stderr)
+  process.exit(pack.status ?? 1)
+}
+
+const [payload] = JSON.parse(pack.stdout)
+const files = payload.files.map((file) => file.path)
+
+assertIncludes(files, "dist/index.js")
+assertIncludes(files, "dist/modules.js")
+assertFileCount(files, /^dist\/configs\/.+\.js$/, 16)
+assertFileCount(files, /^dist\/oxlint-configs\/.+\.json$/, 8)
+
+const entrypoint = new URL("dist/index.js", packageDirectory)
+const { getEslintConfig, getOxlintConfig } = await import(
+  entrypoint.href
+)
+
+const eslintConfig = await getEslintConfig({
+  react: true,
+  ai: true,
+  oxlint: true,
+})
+
+if (!Array.isArray(eslintConfig) || eslintConfig.length === 0) {
+  throw new Error("Expected getEslintConfig() to return a non-empty config array")
+}
+
+const oxlintConfig = getOxlintConfig({
+  react: true,
+  ai: true,
+})
+
+if (typeof oxlintConfig !== "object" || oxlintConfig === null) {
+  throw new Error("Expected getOxlintConfig() to return a config object")
+}
+
+function assertIncludes(files, expected) {
+  if (!files.includes(expected)) {
+    throw new Error(`Package payload is missing ${expected}`)
+  }
+}
+
+function assertFileCount(files, pattern, expectedCount) {
+  const count = files.filter((file) => pattern.test(file)).length
+
+  if (count !== expectedCount) {
+    throw new Error(
+      `Expected ${expectedCount} package files matching ${pattern}, found ${count}`,
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add PR gates for lint, docs build, dependency audit policy, and package smoke checks
- add `scripts/check-package-smoke.mjs` to verify the packed package includes generated ESLint/OxLint configs and that public loaders work from `dist/`
- run the same lint, React rule surface, and package smoke checks before npm publish

Fixes #73.

## Validation
- `CI=true pnpm build`
- `CI=true pnpm generate`
- `CI=true pnpm lint`
- `CI=true pnpm run smoke:package`
- `CI=true pnpm audit --audit-level moderate`
- `CI=true pnpm check`
- `CI=true pnpm react:rules:check`
- `CI=true pnpm test`
- `CI=true pnpm docs:build`
- pre-push hook: `pnpm lint:self && pnpm lint:docs`